### PR TITLE
Allow parsing pointvalue types (geopoints)

### DIFF
--- a/leveldb_export/utils.py
+++ b/leveldb_export/utils.py
@@ -39,7 +39,7 @@ def get_value(value: Dict, raw=False):
         # not certain why, but without the cast to `int` here it shows up as a str in the output
         return int(v)
 
-    return value.get("doubleValue", value.get("booleanValue"))
+    return value.get("doubleValue", value.get("booleanValue", value.get("pointvalue")))
 
 
 def embedded_entity_to_dict(embedded_entity, data):


### PR DESCRIPTION
Pointvalue is one of the entity types in https://chromium.googlesource.com/external/googleappengine/python/+/7e0ab775c587657f0f93a3134f2db99e46bb98bd/google/appengine/datastore/entity_pb.py. Most commonly it is used to represent geopoints.

I am unsure why the property name is lowercase when all the others are camelcase, but I have tested this with a Firestore export and it is indeed the case.